### PR TITLE
자료형 도메인 설계하기

### DIFF
--- a/src/main/java/com/testdata/domain/SchemaField.java
+++ b/src/main/java/com/testdata/domain/SchemaField.java
@@ -1,5 +1,6 @@
 package com.testdata.domain;
 
+import com.testdata.domain.constant.MockDataType;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.ToString;
@@ -10,7 +11,7 @@ import lombok.ToString;
 public class SchemaField {
 
 	private String fieldName;
-	private String mockDataType;
+	private MockDataType mockDataType;
 	private Integer fieldOrder;
 	private Integer blankPercent;
 	private String typeOptionJson;

--- a/src/main/java/com/testdata/domain/constant/MockDataType.java
+++ b/src/main/java/com/testdata/domain/constant/MockDataType.java
@@ -1,0 +1,45 @@
+package com.testdata.domain.constant;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import java.util.Set;
+
+@Getter
+@RequiredArgsConstructor
+public enum MockDataType {
+	STRING(Set.of("minLength", "maxLength", "pattern"), null),
+	NUMBER(Set.of("min", "max", "decimals"), null),
+	BOOLEAN(Set.of(), null),
+	DATETIME(Set.of("from", "to"), null),
+	ENUM(Set.of("elements"), null),
+
+	SENTENCE(Set.of("minSentences", "maxSentences"), STRING),
+	PARAGRAPH(Set.of("minParagraphs", "maxParagraphs"), STRING),
+	UUID(Set.of(), STRING),
+	EMAIL(Set.of(), STRING),
+	CAR(Set.of(), STRING),
+	ROW_NUMBER(Set.of("start, step"), NUMBER),
+	NAME(Set.of(), STRING);
+
+	private final Set<String> requiredOptions;
+	private final MockDataType baseType;
+
+	public boolean isBaseType() {
+		return baseType == null;
+	}
+
+	public MockDataTypeObject toObject() {
+		return new MockDataTypeObject(
+				this.name(),
+				this.requiredOptions,
+				this.baseType == null ? null : this.baseType.name()
+		);
+	}
+
+	public record MockDataTypeObject(
+			String name,
+			Set<String> requiredOptions,
+			String baseType) {
+	}
+}

--- a/src/test/java/com/testdata/domain/constant/MockDataTypeTest.java
+++ b/src/test/java/com/testdata/domain/constant/MockDataTypeTest.java
@@ -1,0 +1,37 @@
+package com.testdata.domain.constant;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("[Domain] 테스트 데이터 자료형 테스트")
+class MockDataTypeTest {
+
+	@DisplayName("자료형이 주어지면, 해당 원소의 이름을 리턴한다.")
+	@Test
+	void givenMockDataType_whenReading_thenReturnsEnumElementName() {
+		// given
+		MockDataType mockDataType = MockDataType.STRING;
+
+		// when
+		String elementName = mockDataType.toString();
+
+		// then
+		assertThat(elementName).isEqualTo(MockDataType.STRING.name());
+	}
+
+	@DisplayName("자료형이 주어지, 해당 원소의 데이터를 리턴한다.")
+	@Test
+	void givenMockDataType_whenReading_thenReturnsEnumElementObject() {
+		// given
+		MockDataType mockDataType = MockDataType.STRING;
+
+		// when
+		MockDataType.MockDataTypeObject result = MockDataType.STRING.toObject();
+
+		// then
+		assertThat(result.toString()).contains("name", "requiredOptions", "baseType");
+	}
+
+}


### PR DESCRIPTION
이 pr은 가짜 데이터의 자료형 도메인을 `enum`으로 설계하고, 문자열로 직렬화할 경우에 필요할 것으로 예상되는 정보를 추가로 정의하였다.

This closes #8 